### PR TITLE
install homebrew if missing

### DIFF
--- a/homebrew.sh
+++ b/homebrew.sh
@@ -1,6 +1,6 @@
-# check if homebrew is installed.
-# todo: install when necessary.
-which brew > /dev/null || (echo 'homebrew is not installed. exiting.' && exit 1)
+if [[ ! $(which brew) > /dev/null ]]; then
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+fi
 
 PACKAGES=(
   awscli
@@ -20,7 +20,11 @@ PACKAGES=(
 )
 
 for PACKAGE in "${PACKAGES[@]}"; do
-  brew list $PACKAGE || brew install $PACKAGE
+  if [[ $(brew list $PACKAGE) > /dev/null ]]; then
+    echo "$PACKAGE is installed."
+  else
+    brew install $PACKAGE
+  fi
 done
 
 git secrets --register-aws --global


### PR DESCRIPTION
Install homebrew if missing. Installation one-liner comes from: https://brew.sh/
It attempts to fetch only when `brew` command is absent.

Also suppressed verbose output from `brew list`, providing instead easy conditional to check if given formula has been installed.