### PR TITLE
check and clone ohmyzsh when missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 git-completion.bash
 git-prompt.sh
-ohmyzsh
 solarized.vim

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ohmyzsh"]
-	path = ohmyzsh
-	url = https://github.com/ohmyzsh/ohmyzsh

--- a/.zshrc
+++ b/.zshrc
@@ -1,4 +1,8 @@
-export ZSH=$HOME/dotfiles/ohmyzsh
+if [ ! -d $HOME/ohmyzsh ]; then
+  git clone https://github.com/ohmyzsh/ohmyzsh.git $HOME/ohmyzsh
+fi
+
+export ZSH=$HOME/ohmyzsh
 
 ZSH_THEME="agnoster"
 plugins=(


### PR DESCRIPTION
nursing submodules is tedious. simply check the presence of `ohmyzsh` in `.zshrc` and clone duly if it's missing.