### PR TITLE
change ghq root path

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -71,4 +71,4 @@
 [init]
 	templatedir = ~/.git-templates/git-secrets
 [ghq]
-	root = ~/go/src
+	root = ~/src


### PR DESCRIPTION
moving ghq root directory out of `~/go`. for existing configuration, simply move the entire `src` directory out of `~/go` and it works. peco works too.