### PR TITLE
Update the list of the essential casks

### DIFF
--- a/homebrew.sh
+++ b/homebrew.sh
@@ -39,7 +39,6 @@ CASKS=(
   evernote
   flux
   iterm2
-  skitch
   slack
   visual-studio-code
   workflowy

--- a/homebrew.sh
+++ b/homebrew.sh
@@ -35,6 +35,7 @@ CASKS=(
   1password
   alfred
   aws-vault
+  bettertouchtool
   docker
   evernote
   flux


### PR DESCRIPTION
skitch is not available when you first install it via cask for some reasons.
bettertouchtool is a personal essential and thus is now incorporated in the script.