### PR TITLE
skip verification of site-functions installed by homebrew

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -3,6 +3,7 @@ if [ ! -d $HOME/ohmyzsh ]; then
 fi
 
 export ZSH=$HOME/ohmyzsh
+export ZSH_DISABLE_COMPFIX="true"
 
 ZSH_THEME="agnoster"
 plugins=(


### PR DESCRIPTION
oh-my-zsh has claimed to find insecure dirs. Below is the original message.

```
[oh-my-zsh] Insecure completion-dependent directories detected:
drwxrwxr-x   3 <username>  admin   96 Jan 31 10:40 /usr/local/share/zsh
drwxrwxr-x  10 <username>  admin  320 Feb  3 15:57 /usr/local/share/zsh/site-functions

[oh-my-zsh] For safety, we will not load completions from these directories until
[oh-my-zsh] you fix their permissions and ownership and restart zsh.
[oh-my-zsh] See the above list for directories with group or other writability.

[oh-my-zsh] To fix your permissions you can do so by disabling
[oh-my-zsh] the write permission of "group" and "others" and making sure that the
[oh-my-zsh] owner of these directories is either root or your current user.
[oh-my-zsh] The following command may help:
[oh-my-zsh]     compaudit | xargs chmod g-w,o-w

[oh-my-zsh] If the above didn't help or you want to skip the verification of
[oh-my-zsh] insecure directories you can set the variable ZSH_DISABLE_COMPFIX to
[oh-my-zsh] "true" before oh-my-zsh is sourced in your zshrc file.
```

The named directories, however, are added by homebrew's git formula and therefore I reckon it safe. See the excerpt of the message generated by `brew info git`:

```
zsh completions and functions have been installed to:
  /usr/local/share/zsh/site-functions
```