### PR TITLE
Prefer gcc-9

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -4,6 +4,10 @@ alias ll='ls -l'
 alias la='ls -a'
 alias lal='la -al'
 
+# supposing gcc@9 is installed via brew
+alias gcc='gcc-9'
+alias g++='g++-9'
+
 # Rails
 alias b='bundle exec'
 alias bs='bundle exec spring'

--- a/homebrew.sh
+++ b/homebrew.sh
@@ -4,7 +4,7 @@ fi
 
 PACKAGES=(
   awscli
-  gcc
+  gcc@9
   ghq
   git
   git-flow


### PR DESCRIPTION
`gcc` had lately been upgraded to v11 and I found I did not need the up-to-date version.
Since AtCoder specifies gcc version to 9.2.1 I'm following the nearest version distribution which is gcc 9.3 as of today.