### PR TITLE
Prefer older version of btt to the latest one

### DIFF
--- a/homebrew.sh
+++ b/homebrew.sh
@@ -36,7 +36,6 @@ CASKS=(
   1password
   alfred
   aws-vault
-  bettertouchtool
   docker
   evernote
   flux


### PR DESCRIPTION
The version i'm eligible to use is 3.402 and i do not want cask to upgrade it automatically.