### PR TITLE
Open pr from commit

### DIFF
--- a/.vscode/keybindings.json
+++ b/.vscode/keybindings.json
@@ -1,0 +1,7 @@
+[
+  {
+    "key": "ctrl+c g",
+    "command": "gitlens.copyShaToClipboard",
+    "when": "editorTextFocus"
+  }
+]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "gitlens.advanced.abbreviateShaOnCopy": true
+}

--- a/.zshrc
+++ b/.zshrc
@@ -4,6 +4,7 @@ fi
 
 export ZSH=$HOME/ohmyzsh
 export ZSH_DISABLE_COMPFIX="true"
+export PATH=$PATH:$HOME/bin
 
 ZSH_THEME="agnoster"
 plugins=(

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ deploy: ## Create symlink to home directory
 	ln -sfnv ~/dotfiles/.vimrc ~/
 	ln -sfnv ~/dotfiles/.zshrc ~/
 	ln -sfnv ~/dotfiles/.vim ~/
+	ln -sfnv ~/dotfiles/.vscode/keybindings.json ~/Library/Application\ Support/Code/User/keybindings.json
+	ln -sfnv ~/dotfiles/.vscode/settings.json ~/Library/Application\ Support/Code/User/settings.json
 	ln -sfnv ~/dotfiles/bin ~/
 
 fetch:
@@ -26,6 +28,8 @@ unlink:
 	unlink ~/.vimrc
 	unlink ~/.zshrc
 	unlink ~/.vim
+	unlink ~/Library/Application\ Support/Code/User/keybindings.json
+	unlink ~/Library/Application\ Support/Code/User/settings.json
 	unlink ~/bin
 
 update:

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-EXCLUSIONS := .DS_Store .git .gitignore
-CANDIDATES := $(wildcard .??*)
-DOTFILES   := $(filter-out $(EXCLUSIONS), $(CANDIDATES))
-
 deploy: ## Create symlink to home directory
 	@echo '==> Start to deploy dotfiles to home directory.'
-	@$(foreach val, $(DOTFILES), ln -sfnv $(abspath $(val)) $(HOME)/$(val);)
+	ln -sfnv ~/dotfiles/.aliases ~/
+	ln -sfnv ~/dotfiles/.gitconfig ~/
+	ln -sfnv ~/dotfiles/.gitignore_global ~/
+	ln -sfnv ~/dotfiles/.tmux.conf ~/
+	ln -sfnv ~/dotfiles/.vimrc ~/
+	ln -sfnv ~/dotfiles/.zshrc ~/
+	ln -sfnv ~/dotfiles/.vim ~/
+	ln -sfnv ~/dotfiles/bin ~/
 
 fetch:
 	test -f .vim/colors/solarized.vim || (mkdir -p .vim/colors && curl -o .vim/colors/solarized.vim -O https://raw.githubusercontent.com/altercation/vim-colors-solarized/master/colors/solarized.vim)
@@ -16,7 +19,14 @@ install: update fetch deploy
 
 unlink:
 	@echo '==> Unlinking dotfiles.'
-	@-$(foreach val, $(DOTFILES), unlink $(HOME)/$(val) && echo Removed $(HOME)/$(val);)
+	unlink ~/.aliases
+	unlink ~/.gitconfig
+	unlink ~/.gitignore_global
+	unlink ~/.tmux.conf
+	unlink ~/.vimrc
+	unlink ~/.zshrc
+	unlink ~/.vim
+	unlink ~/bin
 
 update:
 	git pull origin main

--- a/bin/open-pr-from-commit
+++ b/bin/open-pr-from-commit
@@ -1,0 +1,3 @@
+#!/bin/bash
+default_branch=`git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'`
+gh browse -- `git log --merges --oneline --reverse --ancestry-path $1...$default_branch | grep 'Merge pull request #' | head -n 1 | cut -f5 -d' ' | sed -e 's%#%%'`

--- a/homebrew.sh
+++ b/homebrew.sh
@@ -5,6 +5,7 @@ fi
 PACKAGES=(
   awscli
   gcc@9
+  gh
   ghq
   git
   git-flow


### PR DESCRIPTION
Define `open-pr-from-commit` executable which takes commit-SHA as the argument and opens the pull-request that includes the commit. This introduces dependency to `gh` command, which is added to brew default members.

Also added the vscode keybinding to get SHA via gitlens extension, so I can get shortcut to gain SHA and can just pass it to `open-pr-from-commit`.

Tweaked Makefile a bit since the previous version full of magic wasn't flexible enough symlinking. Instead of inventing another elaboration I abandoned loops and described every link/unlink step. Don't think this is worse.