### PR TITLE
Interpret `*.jb` files as ruby

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,8 @@
   "gitlens.advanced.abbreviateShaOnCopy": true,
   "editor.tabSize": 2,
   "files.insertFinalNewline": true,
-  "files.trimFinalNewlines": true
+  "files.trimFinalNewlines": true,
+  "files.associations": {
+    "*.jb": "ruby"
+  }
 }


### PR DESCRIPTION
In order to highlight files where https://github.com/amatsuda/jb is in use.

Read this to see how the configuration is done:
https://stackoverflow.com/a/51228725